### PR TITLE
Completed prep-css-display exercise.

### DIFF
--- a/prep-css-display/.npmrc
+++ b/prep-css-display/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/prep-css-display/index.html
+++ b/prep-css-display/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CSS Display Properties</title>
+  <style>
+    div {
+      border: 4px solid blue;
+    }
+
+    span {
+      border: 4px solid green;
+      width: 100px;
+      height: 100px;
+    }
+
+    button {
+      border: 4px solid red;
+      height: 40px;
+      width: 200px;
+    }
+
+    ul {
+      border: 4px solid purple;
+    }
+
+    li {
+      border: 4px solid magenta;
+      display: inline;
+    }
+  </style>
+</head>
+<body>
+  <div>I am a div and by default I am block, which means I take up all the space I can horizontally.</div>
+  <div>
+    I am a div but I have <span>span elements inside me</span>.
+    Span elements are <span>display inline by default</span>,
+    so they only take up as much as space as they need.
+  </div>
+  <div>
+    <button>Hello!</button>
+    <button>Buttons are</button>
+    <button>Inline Block</button>
+    <button>By Default</button>
+  </div>
+  <ul>
+    <li>
+      Home
+    </li>
+    <li>
+      Products
+    </li>
+    <li>
+      About Us
+    </li>
+    <li>
+      Contact Us
+    </li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
![prep-css-display](https://user-images.githubusercontent.com/113082803/191670460-d58c3b00-02b3-4ef5-bbdc-1b1aea59ebc7.JPG)


Side note: I discovered that I had a second border line created, which may have been caused by my Google Chrome Extension.

Attached below:
![ERROR prep-css-display](https://user-images.githubusercontent.com/113082803/191670598-32fef233-0c36-4be0-8d22-efb8aa742fa8.JPG)

Please let me know if this is fine or if I need to redo.